### PR TITLE
Add Telegram polling and message handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ npm-debug.log
 *.db
 *.db-*
 
+
+.env

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,9 +52,9 @@ Telegram → Poller → Conversation.Server → Task.Server → Agent/MCP → Re
 1. **Test isolation**: Each test must have its state scoped to that test only. No global state modification.
 
 2. **No shared state**: Tests must not depend on or modify:
-   - Global application state
+   - Global application state (never use `Application.put_env` in tests)
    - Shared database records (use sandbox)
-   - Environment variables (use Application.put_env in setup, restore in on_exit)
+   - Environment variables
    - File system (use tmp_dir or mock)
 
 3. **Use Mimic for mocking**:

--- a/README.md
+++ b/README.md
@@ -71,12 +71,9 @@ export TELEGRAM_ALLOWED_USERS="123456789"
 
 # Which coding agent to use: "claude_code" or "codex"
 export GESTALT_CODING_AGENT="claude_code"
-
-# API key for your chosen coding agent
-export ANTHROPIC_API_KEY="sk-ant-..."  # For Claude Code
-# or
-export OPENAI_API_KEY="sk-..."          # For Codex
 ```
+
+Note: Coding agents (Claude Code, Codex) manage their own authentication. Make sure you've authenticated with your chosen agent before running Gestalt (e.g., run `claude` to set up Claude Code).
 
 ### Production Environment
 
@@ -203,7 +200,6 @@ Environment=SECRET_KEY_BASE=your-secret-key
 Environment=TELEGRAM_BOT_TOKEN=your-token
 Environment=TELEGRAM_ALLOWED_USERS=123456789
 Environment=GESTALT_CODING_AGENT=claude_code
-Environment=ANTHROPIC_API_KEY=your-key
 ExecStart=/usr/bin/mise exec -C /opt/gestalt -- /opt/gestalt/_build/prod/rel/gestalt/bin/gestalt start
 Restart=on-failure
 
@@ -254,8 +250,6 @@ Create `~/Library/LaunchAgents/com.gestalt.plist`:
         <string>123456789</string>
         <key>GESTALT_CODING_AGENT</key>
         <string>claude_code</string>
-        <key>ANTHROPIC_API_KEY</key>
-        <string>your-key</string>
     </dict>
     <key>RunAtLoad</key>
     <true/>
@@ -283,7 +277,7 @@ Use [NSSM (Non-Sucking Service Manager)](https://nssm.cc/) to run Gestalt as a W
    ```cmd
    nssm install Gestalt C:\Users\YourUser\.local\bin\mise.exe exec -C C:\gestalt -- C:\gestalt\_build\prod\rel\gestalt\bin\gestalt.bat start
    nssm set Gestalt AppDirectory C:\gestalt
-   nssm set Gestalt AppEnvironmentExtra PHX_SERVER=true DATABASE_PATH=C:\gestalt\gestalt.db SECRET_KEY_BASE=your-secret-key TELEGRAM_BOT_TOKEN=your-token TELEGRAM_ALLOWED_USERS=123456789 GESTALT_CODING_AGENT=claude_code ANTHROPIC_API_KEY=your-key
+   nssm set Gestalt AppEnvironmentExtra PHX_SERVER=true DATABASE_PATH=C:\gestalt\gestalt.db SECRET_KEY_BASE=your-secret-key TELEGRAM_BOT_TOKEN=your-token TELEGRAM_ALLOWED_USERS=123456789 GESTALT_CODING_AGENT=claude_code
    nssm start Gestalt
    ```
 

--- a/lib/gestalt/application.ex
+++ b/lib/gestalt/application.ex
@@ -7,18 +7,17 @@ defmodule Gestalt.Application do
 
   @impl true
   def start(_type, _args) do
-    children = [
-      GestaltWeb.Telemetry,
-      Gestalt.Repo,
-      {Ecto.Migrator,
-       repos: Application.fetch_env!(:gestalt, :ecto_repos), skip: skip_migrations?()},
-      {DNSCluster, query: Application.get_env(:gestalt, :dns_cluster_query) || :ignore},
-      {Phoenix.PubSub, name: Gestalt.PubSub},
-      # Start a worker by calling: Gestalt.Worker.start_link(arg)
-      # {Gestalt.Worker, arg},
-      # Start to serve requests, typically the last entry
-      GestaltWeb.Endpoint
-    ]
+    children =
+      [
+        GestaltWeb.Telemetry,
+        Gestalt.Repo,
+        {Ecto.Migrator,
+         repos: Application.fetch_env!(:gestalt, :ecto_repos), skip: skip_migrations?()},
+        {DNSCluster, query: Application.get_env(:gestalt, :dns_cluster_query) || :ignore},
+        {Phoenix.PubSub, name: Gestalt.PubSub},
+        # Start to serve requests, typically the last entry
+        GestaltWeb.Endpoint
+      ] ++ telegram_children()
 
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options
@@ -37,5 +36,15 @@ defmodule Gestalt.Application do
   defp skip_migrations? do
     # By default, sqlite migrations are run when using a release
     System.get_env("RELEASE_NAME") == nil
+  end
+
+  defp telegram_children do
+    telegram_config = Application.get_env(:gestalt, :telegram)
+
+    if telegram_config[:bot_token] do
+      [Gestalt.Telegram.Poller]
+    else
+      []
+    end
   end
 end

--- a/lib/gestalt/telegram/client.ex
+++ b/lib/gestalt/telegram/client.ex
@@ -1,0 +1,119 @@
+defmodule Gestalt.Telegram.Client do
+  @moduledoc """
+  HTTP client for the Telegram Bot API.
+  """
+
+  @base_url "https://api.telegram.org"
+
+  @doc """
+  Fetches updates from the Telegram API using long polling.
+
+  ## Options
+    - `:offset` - Identifier of the first update to be returned
+    - `:timeout` - Timeout in seconds for long polling (default: 30)
+    - `:bot_token` - Bot token (defaults to config)
+  """
+  @spec get_updates(keyword()) :: {:ok, list(map())} | {:error, term()}
+  def get_updates(opts \\ []) do
+    offset = Keyword.get(opts, :offset)
+    timeout = Keyword.get(opts, :timeout, 30)
+    bot_token = Keyword.get_lazy(opts, :bot_token, &bot_token/0)
+
+    params =
+      %{timeout: timeout}
+      |> maybe_put(:offset, offset)
+
+    case request(:get, "/getUpdates", params, bot_token) do
+      {:ok, %{"ok" => true, "result" => updates}} ->
+        {:ok, updates}
+
+      {:ok, %{"ok" => false, "description" => description}} ->
+        {:error, description}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @doc """
+  Sends a text message to a chat.
+
+  ## Options
+    - `:parse_mode` - Parse mode for the message (e.g., "Markdown", "HTML")
+    - `:reply_to_message_id` - Message ID to reply to
+    - `:bot_token` - Bot token (defaults to config)
+  """
+  @spec send_message(integer(), String.t(), keyword()) :: {:ok, map()} | {:error, term()}
+  def send_message(chat_id, text, opts \\ []) do
+    parse_mode = Keyword.get(opts, :parse_mode)
+    reply_to_message_id = Keyword.get(opts, :reply_to_message_id)
+    bot_token = Keyword.get_lazy(opts, :bot_token, &bot_token/0)
+
+    params =
+      %{chat_id: chat_id, text: text}
+      |> maybe_put(:parse_mode, parse_mode)
+      |> maybe_put(:reply_to_message_id, reply_to_message_id)
+
+    case request(:post, "/sendMessage", params, bot_token) do
+      {:ok, %{"ok" => true, "result" => message}} ->
+        {:ok, message}
+
+      {:ok, %{"ok" => false, "description" => description}} ->
+        {:error, description}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @doc """
+  Gets information about the bot.
+
+  ## Options
+    - `:bot_token` - Bot token (defaults to config)
+  """
+  @spec get_me(keyword()) :: {:ok, map()} | {:error, term()}
+  def get_me(opts \\ []) do
+    bot_token = Keyword.get_lazy(opts, :bot_token, &bot_token/0)
+
+    case request(:get, "/getMe", %{}, bot_token) do
+      {:ok, %{"ok" => true, "result" => bot_info}} ->
+        {:ok, bot_info}
+
+      {:ok, %{"ok" => false, "description" => description}} ->
+        {:error, description}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp request(method, path, params, bot_token) do
+    url = "#{@base_url}/bot#{bot_token}#{path}"
+
+    req_opts =
+      case method do
+        :get -> [params: params]
+        :post -> [json: params]
+      end
+
+    case Req.request([method: method, url: url] ++ req_opts) do
+      {:ok, %Req.Response{status: 200, body: body}} ->
+        {:ok, body}
+
+      {:ok, %Req.Response{status: status, body: body}} ->
+        {:error, {:http_error, status, body}}
+
+      {:error, exception} ->
+        {:error, exception}
+    end
+  end
+
+  defp bot_token do
+    Application.get_env(:gestalt, :telegram)[:bot_token] ||
+      raise "TELEGRAM_BOT_TOKEN is not configured"
+  end
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+end

--- a/lib/gestalt/telegram/poller.ex
+++ b/lib/gestalt/telegram/poller.ex
@@ -1,0 +1,148 @@
+defmodule Gestalt.Telegram.Poller do
+  @moduledoc """
+  GenServer that polls for Telegram updates using long polling.
+
+  This process continuously fetches updates from the Telegram API and
+  processes incoming messages. It filters messages to only allow
+  configured users.
+  """
+
+  use GenServer
+
+  alias Gestalt.Telegram.Client
+
+  require Logger
+
+  @poll_timeout 30
+  @error_backoff 5_000
+
+  # Client API
+
+  @doc """
+  Starts the Telegram poller.
+
+  ## Options
+    - `:name` - Process name (defaults to `__MODULE__`)
+    - `:allowed_users` - List of allowed Telegram user IDs
+    - `:error_backoff` - Backoff time in ms after errors (default: 5000)
+  """
+  def start_link(opts \\ []) do
+    {name, opts} = Keyword.pop(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  # Server Callbacks
+
+  @impl true
+  def init(opts) do
+    state = %{
+      offset: nil,
+      allowed_users: Keyword.get(opts, :allowed_users, allowed_users()),
+      error_backoff: Keyword.get(opts, :error_backoff, @error_backoff),
+      auto_poll: Keyword.get(opts, :auto_poll, true)
+    }
+
+    if state.auto_poll do
+      {:ok, state, {:continue, :poll}}
+    else
+      {:ok, state}
+    end
+  end
+
+  @doc """
+  Triggers a single poll cycle. Used for testing.
+  """
+  def poll(server \\ __MODULE__) do
+    GenServer.call(server, :poll)
+  end
+
+  @impl true
+  def handle_call(:poll, _from, state) do
+    state = poll_and_process(state)
+    {:reply, :ok, state}
+  end
+
+  @impl true
+  def handle_continue(:poll, state) do
+    state = poll_and_process(state)
+    {:noreply, state, {:continue, :poll}}
+  end
+
+  @impl true
+  def handle_info(:poll, state) do
+    state = poll_and_process(state)
+    {:noreply, state, {:continue, :poll}}
+  end
+
+  # Private Functions
+
+  defp poll_and_process(state) do
+    case Client.get_updates(offset: state.offset, timeout: @poll_timeout) do
+      {:ok, []} ->
+        state
+
+      {:ok, updates} ->
+        process_updates(updates, state.allowed_users)
+        new_offset = get_next_offset(updates)
+        %{state | offset: new_offset}
+
+      {:error, reason} ->
+        Logger.error("Failed to fetch Telegram updates: #{inspect(reason)}")
+        Process.sleep(state.error_backoff)
+        state
+    end
+  end
+
+  defp process_updates(updates, allowed_users) do
+    Enum.each(updates, fn update ->
+      process_update(update, allowed_users)
+    end)
+  end
+
+  defp process_update(%{"message" => message}, allowed_users) do
+    user_id = get_in(message, ["from", "id"])
+    chat_id = get_in(message, ["chat", "id"])
+    text = message["text"]
+
+    cond do
+      user_id == nil ->
+        Logger.debug("Ignoring message without user_id")
+
+      allowed_users != [] and user_id not in allowed_users ->
+        Logger.warning("Ignoring message from unauthorized user: #{user_id}")
+
+      text == nil ->
+        Logger.debug("Ignoring non-text message")
+
+      true ->
+        handle_message(chat_id, user_id, text)
+    end
+  end
+
+  defp process_update(_update, _allowed_users) do
+    :ok
+  end
+
+  defp handle_message(chat_id, user_id, text) do
+    Logger.info("Received message from user #{user_id}: #{text}")
+
+    case Client.send_message(chat_id, "Ack: #{text}") do
+      {:ok, _} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.error("Failed to send message: #{inspect(reason)}")
+    end
+  end
+
+  defp get_next_offset(updates) do
+    updates
+    |> List.last()
+    |> Map.get("update_id")
+    |> Kernel.+(1)
+  end
+
+  defp allowed_users do
+    Application.get_env(:gestalt, :telegram)[:allowed_users] || []
+  end
+end

--- a/mise.toml
+++ b/mise.toml
@@ -7,3 +7,6 @@ erlang = "latest"
 "node" = "24.11.1"
 "npm:@openai/codex" = "0.63.0"
 "npm:@anthropic-ai/claude-code" = "2.0.55"
+
+[env]
+_.file = '.env'

--- a/test/gestalt/telegram/client_test.exs
+++ b/test/gestalt/telegram/client_test.exs
@@ -1,0 +1,174 @@
+defmodule Gestalt.Telegram.ClientTest do
+  use ExUnit.Case, async: true
+
+  import Mimic
+
+  alias Gestalt.Telegram.Client
+
+  setup :set_mimic_private
+
+  describe "get_updates/1" do
+    test "returns updates on success" do
+      expect(Req, :request, fn opts ->
+        assert opts[:method] == :get
+        assert opts[:url] == "https://api.telegram.org/bottest-token/getUpdates"
+        assert opts[:params] == %{timeout: 30}
+
+        {:ok,
+         %Req.Response{
+           status: 200,
+           body: %{
+             "ok" => true,
+             "result" => [%{"update_id" => 123, "message" => %{"text" => "hello"}}]
+           }
+         }}
+      end)
+
+      assert {:ok, [%{"update_id" => 123, "message" => %{"text" => "hello"}}]} =
+               Client.get_updates(bot_token: "test-token")
+    end
+
+    test "returns updates with offset" do
+      expect(Req, :request, fn opts ->
+        assert opts[:params] == %{timeout: 30, offset: 100}
+
+        {:ok,
+         %Req.Response{
+           status: 200,
+           body: %{"ok" => true, "result" => []}
+         }}
+      end)
+
+      assert {:ok, []} = Client.get_updates(bot_token: "test-token", offset: 100)
+    end
+
+    test "returns error on API failure" do
+      expect(Req, :request, fn _opts ->
+        {:ok,
+         %Req.Response{
+           status: 200,
+           body: %{"ok" => false, "description" => "Unauthorized"}
+         }}
+      end)
+
+      assert {:error, "Unauthorized"} = Client.get_updates(bot_token: "test-token")
+    end
+
+    test "returns error on HTTP error" do
+      expect(Req, :request, fn _opts ->
+        {:ok,
+         %Req.Response{
+           status: 500,
+           body: %{"error" => "Internal Server Error"}
+         }}
+      end)
+
+      assert {:error, {:http_error, 500, %{"error" => "Internal Server Error"}}} =
+               Client.get_updates(bot_token: "test-token")
+    end
+
+    test "returns error on network failure" do
+      expect(Req, :request, fn _opts ->
+        {:error, %Req.TransportError{reason: :timeout}}
+      end)
+
+      assert {:error, %Req.TransportError{reason: :timeout}} =
+               Client.get_updates(bot_token: "test-token")
+    end
+  end
+
+  describe "send_message/3" do
+    test "sends message successfully" do
+      expect(Req, :request, fn opts ->
+        assert opts[:method] == :post
+        assert opts[:url] == "https://api.telegram.org/bottest-token/sendMessage"
+        assert opts[:json] == %{chat_id: 123, text: "Hello!"}
+
+        {:ok,
+         %Req.Response{
+           status: 200,
+           body: %{"ok" => true, "result" => %{"message_id" => 456}}
+         }}
+      end)
+
+      assert {:ok, %{"message_id" => 456}} =
+               Client.send_message(123, "Hello!", bot_token: "test-token")
+    end
+
+    test "sends message with parse_mode" do
+      expect(Req, :request, fn opts ->
+        assert opts[:json] == %{chat_id: 123, text: "*bold*", parse_mode: "Markdown"}
+
+        {:ok,
+         %Req.Response{
+           status: 200,
+           body: %{"ok" => true, "result" => %{"message_id" => 456}}
+         }}
+      end)
+
+      assert {:ok, _} =
+               Client.send_message(123, "*bold*", bot_token: "test-token", parse_mode: "Markdown")
+    end
+
+    test "sends message with reply_to_message_id" do
+      expect(Req, :request, fn opts ->
+        assert opts[:json] == %{chat_id: 123, text: "Reply", reply_to_message_id: 789}
+
+        {:ok,
+         %Req.Response{
+           status: 200,
+           body: %{"ok" => true, "result" => %{"message_id" => 456}}
+         }}
+      end)
+
+      assert {:ok, _} =
+               Client.send_message(123, "Reply",
+                 bot_token: "test-token",
+                 reply_to_message_id: 789
+               )
+    end
+
+    test "returns error on failure" do
+      expect(Req, :request, fn _opts ->
+        {:ok,
+         %Req.Response{
+           status: 200,
+           body: %{"ok" => false, "description" => "Chat not found"}
+         }}
+      end)
+
+      assert {:error, "Chat not found"} =
+               Client.send_message(123, "Hello!", bot_token: "test-token")
+    end
+  end
+
+  describe "get_me/1" do
+    test "returns bot info on success" do
+      expect(Req, :request, fn opts ->
+        assert opts[:method] == :get
+        assert opts[:url] == "https://api.telegram.org/bottest-token/getMe"
+
+        {:ok,
+         %Req.Response{
+           status: 200,
+           body: %{"ok" => true, "result" => %{"id" => 123, "username" => "test_bot"}}
+         }}
+      end)
+
+      assert {:ok, %{"id" => 123, "username" => "test_bot"}} =
+               Client.get_me(bot_token: "test-token")
+    end
+
+    test "returns error on failure" do
+      expect(Req, :request, fn _opts ->
+        {:ok,
+         %Req.Response{
+           status: 200,
+           body: %{"ok" => false, "description" => "Unauthorized"}
+         }}
+      end)
+
+      assert {:error, "Unauthorized"} = Client.get_me(bot_token: "test-token")
+    end
+  end
+end

--- a/test/gestalt/telegram/poller_test.exs
+++ b/test/gestalt/telegram/poller_test.exs
@@ -1,0 +1,125 @@
+defmodule Gestalt.Telegram.PollerTest do
+  use ExUnit.Case, async: true
+
+  import Mimic
+
+  alias Gestalt.Telegram.Client
+  alias Gestalt.Telegram.Poller
+
+  setup :set_mimic_private
+
+  defp start_poller(context, opts) do
+    name = :"poller_#{context.test}"
+
+    default_opts = [
+      name: name,
+      auto_poll: false,
+      error_backoff: 0
+    ]
+
+    {:ok, pid} = Poller.start_link(Keyword.merge(default_opts, opts))
+
+    # Allow the GenServer process to use mocks from the test process
+    allow(Client, self(), pid)
+
+    %{poller: pid, poller_name: name}
+  end
+
+  describe "poll/1" do
+    test "processes messages from allowed users and sends ack", context do
+      test_pid = self()
+      %{poller_name: name} = start_poller(context, allowed_users: [42])
+
+      stub(Client, :get_updates, fn _opts ->
+        {:ok,
+         [
+           %{
+             "update_id" => 123,
+             "message" => %{
+               "from" => %{"id" => 42},
+               "chat" => %{"id" => 42},
+               "text" => "hello"
+             }
+           }
+         ]}
+      end)
+
+      expect(Client, :send_message, fn chat_id, text ->
+        send(test_pid, {:send_message, chat_id, text})
+        {:ok, %{"message_id" => 1}}
+      end)
+
+      Poller.poll(name)
+
+      assert_receive {:send_message, 42, "Ack: hello"}
+    end
+
+    test "ignores messages from unauthorized users", context do
+      %{poller_name: name} = start_poller(context, allowed_users: [42])
+
+      stub(Client, :get_updates, fn _opts ->
+        {:ok,
+         [
+           %{
+             "update_id" => 123,
+             "message" => %{
+               "from" => %{"id" => 999},
+               "chat" => %{"id" => 999},
+               "text" => "hello"
+             }
+           }
+         ]}
+      end)
+
+      reject(&Client.send_message/2)
+
+      Poller.poll(name)
+    end
+
+    test "allows all users when allowed_users is empty", context do
+      test_pid = self()
+      %{poller_name: name} = start_poller(context, allowed_users: [])
+
+      stub(Client, :get_updates, fn _opts ->
+        {:ok,
+         [
+           %{
+             "update_id" => 123,
+             "message" => %{
+               "from" => %{"id" => 999},
+               "chat" => %{"id" => 999},
+               "text" => "hello"
+             }
+           }
+         ]}
+      end)
+
+      expect(Client, :send_message, fn chat_id, text ->
+        send(test_pid, {:send_message, chat_id, text})
+        {:ok, %{"message_id" => 1}}
+      end)
+
+      Poller.poll(name)
+
+      assert_receive {:send_message, 999, "Ack: hello"}
+    end
+
+    test "handles empty updates", context do
+      %{poller_name: name} = start_poller(context, allowed_users: [42])
+
+      stub(Client, :get_updates, fn _opts -> {:ok, []} end)
+      reject(&Client.send_message/2)
+
+      Poller.poll(name)
+    end
+
+    test "handles API errors gracefully", context do
+      %{poller_name: name} = start_poller(context, allowed_users: [42])
+
+      stub(Client, :get_updates, fn _opts -> {:error, "Network error"} end)
+      reject(&Client.send_message/2)
+
+      Poller.poll(name)
+    end
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -2,5 +2,5 @@ ExUnit.start()
 Ecto.Adapters.SQL.Sandbox.mode(Gestalt.Repo, :manual)
 
 # Configure Mimic for mocking
-# Add modules to mock here as needed:
-# Mimic.copy(Gestalt.Telegram.Client)
+Mimic.copy(Gestalt.Telegram.Client)
+Mimic.copy(Req)


### PR DESCRIPTION
## Summary

- Add `Gestalt.Telegram.Client` module for HTTP API calls (get_updates, send_message, get_me)
- Add `Gestalt.Telegram.Poller` GenServer for long-polling Telegram updates
- Integrate poller into application supervision tree (starts only when `TELEGRAM_BOT_TOKEN` is configured)
- Filter messages to allowed users only (via `TELEGRAM_ALLOWED_USERS`)
- Respond with "Ack: <message>" for testing the integration
- Update CLAUDE.md to clarify testing guidelines (no `Application.put_env` in tests)
- Remove unnecessary API key env vars from README (coding agents manage their own authentication)

## Test plan

- [x] Run `mix test` - all tests pass
- [x] Run `mix ci` - compilation, formatting, credo, and tests all pass
- [x] Manual testing: set `TELEGRAM_BOT_TOKEN` and `TELEGRAM_ALLOWED_USERS`, run `mix phx.server`, send message to bot, verify "Ack" response

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Telegram bot integration with a HTTP client and a background poller for handling updates.

* **Refactor**
  * Telegram poller is now started conditionally based on runtime configuration.

* **Documentation**
  * Removed direct API key examples; clarified agents manage their own authentication and users should authenticate chosen agents beforehand.
  * Updated test guidance to avoid global application state in tests.

* **Tests**
  * Added comprehensive tests for Telegram client and poller; enabled mocking in test startup.

* **Chores**
  * Added .env to ignored files and referenced an env file in configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->